### PR TITLE
[Fix/#148] 토큰 401 관리 및 투데이 시간 파싱

### DIFF
--- a/app/src/main/java/org/memento/core/event/GlobalLogoutEvent.kt
+++ b/app/src/main/java/org/memento/core/event/GlobalLogoutEvent.kt
@@ -1,0 +1,7 @@
+package org.memento.core.event
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+object GlobalLogoutEvent {
+    val trigger = MutableSharedFlow<Unit>(replay = 0)
+}

--- a/app/src/main/java/org/memento/data/datastore/TokenDataStoreImpl.kt
+++ b/app/src/main/java/org/memento/data/datastore/TokenDataStoreImpl.kt
@@ -2,11 +2,15 @@ package org.memento.data.datastore
 
 import android.content.SharedPreferences
 import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.memento.core.event.GlobalLogoutEvent
 import javax.inject.Inject
 
 class TokenDataStoreImpl
     @Inject
     constructor(
+        private val applicationScope: CoroutineScope,
         private val sharedPreferences: SharedPreferences,
     ) : TokenDataStore {
         override var accessToken: String
@@ -54,6 +58,9 @@ class TokenDataStoreImpl
         override fun clearInfo() {
             sharedPreferences.edit().clear().apply()
             sharedPreferences.edit().putBoolean(LOGIN_SUCCESS, false).apply()
+            applicationScope.launch {
+                GlobalLogoutEvent.trigger.emit(Unit)
+            }
         }
 
         companion object {

--- a/app/src/main/java/org/memento/data/datastore/TokenDataStoreImpl.kt
+++ b/app/src/main/java/org/memento/data/datastore/TokenDataStoreImpl.kt
@@ -53,6 +53,7 @@ class TokenDataStoreImpl
 
         override fun clearInfo() {
             sharedPreferences.edit().clear().apply()
+            sharedPreferences.edit().putBoolean(LOGIN_SUCCESS, false).apply()
         }
 
         companion object {

--- a/app/src/main/java/org/memento/data/util/Interceptor.kt
+++ b/app/src/main/java/org/memento/data/util/Interceptor.kt
@@ -1,7 +1,5 @@
 package org.memento.data.util
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
@@ -10,7 +8,6 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okio.IOException
 import org.memento.BuildConfig
-import org.memento.core.event.GlobalLogoutEvent
 import org.memento.data.datastore.TokenDataStore
 import org.memento.data.dto.BaseResponse
 import org.memento.data.dto.response.ResponseRefreshDto
@@ -79,9 +76,6 @@ class Interceptor
                         refreshTokenResponse.close()
                         clearUserInfo()
                         tokenDataStore.loginSuccess = false
-                        GlobalScope.launch {
-                            GlobalLogoutEvent.trigger.emit(Unit)
-                        }
                         throw IOException("Failed to refresh token")
                     }
                 }

--- a/app/src/main/java/org/memento/data/util/Interceptor.kt
+++ b/app/src/main/java/org/memento/data/util/Interceptor.kt
@@ -1,5 +1,7 @@
 package org.memento.data.util
 
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
@@ -8,6 +10,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okio.IOException
 import org.memento.BuildConfig
+import org.memento.core.event.GlobalLogoutEvent
 import org.memento.data.datastore.TokenDataStore
 import org.memento.data.dto.BaseResponse
 import org.memento.data.dto.response.ResponseRefreshDto
@@ -74,6 +77,11 @@ class Interceptor
                         Timber.d("❌ Failed to refresh token, response: ${refreshTokenResponse.code}")
                         Timber.d("❌ Error body: $responseBodyString")
                         refreshTokenResponse.close()
+                        clearUserInfo()
+                        tokenDataStore.loginSuccess = false
+                        GlobalScope.launch {
+                            GlobalLogoutEvent.trigger.emit(Unit)
+                        }
                         throw IOException("Failed to refresh token")
                     }
                 }

--- a/app/src/main/java/org/memento/di/CoroutineModule.kt
+++ b/app/src/main/java/org/memento/di/CoroutineModule.kt
@@ -1,0 +1,19 @@
+package org.memento.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutineModule {
+    @Provides
+    @Singleton
+    fun provideApplicationScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default)
+}

--- a/app/src/main/java/org/memento/di/DataStoreModule.kt
+++ b/app/src/main/java/org/memento/di/DataStoreModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
 import org.memento.data.datastore.TokenDataStore
 import org.memento.data.datastore.TokenDataStoreImpl
 import javax.inject.Singleton
@@ -15,8 +16,9 @@ object DataStoreModule {
     @Provides
     @Singleton
     fun provideDataStore(
+        applicationScope: CoroutineScope,
         sharedPreferences: SharedPreferences,
     ): TokenDataStore {
-        return TokenDataStoreImpl(sharedPreferences)
+        return TokenDataStoreImpl(applicationScope, sharedPreferences)
     }
 }

--- a/app/src/main/java/org/memento/presentation/MainActivity.kt
+++ b/app/src/main/java/org/memento/presentation/MainActivity.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.memento.core.event.GlobalLogoutEvent
 import org.memento.data.datastore.TokenDataStore
 import org.memento.presentation.main.MainScreen
 import org.memento.presentation.navigator.rememberMainNavigator
@@ -26,6 +27,7 @@ import org.memento.presentation.navigator.route.MainNavigationBarRoute
 import org.memento.presentation.onboarding.SplashScreen
 import org.memento.presentation.onboarding.navigation.OnboardingRoute
 import org.memento.ui.theme.MEMENTOTheme
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -44,6 +46,14 @@ class MainActivity : ComponentActivity() {
                 delay(SPLASH_SCREEN_DELAY)
                 showSplash = false
             }
+
+            LaunchedEffect(Unit) {
+                GlobalLogoutEvent.trigger.collect {
+                    Timber.d("Logout trigger")
+                    viewModel.setLoggedOut()
+                }
+            }
+
             MEMENTOTheme(darkTheme = isDarkMode) {
                 if (showSplash || entryState is AppEntryState.Loading) {
                     SplashScreen()
@@ -90,6 +100,10 @@ class AppEntryViewModel
                         AppEntryState.LoggedOut
                     }
             }
+        }
+
+        fun setLoggedOut() {
+            _entryState.value = AppEntryState.LoggedOut
         }
     }
 

--- a/app/src/main/java/org/memento/presentation/today/TodayViewModel.kt
+++ b/app/src/main/java/org/memento/presentation/today/TodayViewModel.kt
@@ -18,6 +18,7 @@ import org.memento.domain.repository.AddPlanRepository
 import org.memento.domain.repository.ScheduleRepository
 import org.memento.domain.repository.TodoRepository
 import org.memento.presentation.type.DialogType
+import org.memento.presentation.util.formatTimeRangeWithDuration
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -119,7 +120,11 @@ class TodayViewModel
                                 startDate = response.startDate,
                                 tagColorCode = response.tagColorCode,
                                 tagName = response.tagName,
-                                timeDuration = response.timeDuration,
+                                timeDuration =
+                                    formatTimeRangeWithDuration(
+                                        start = response.startDate,
+                                        end = response.endDate,
+                                    ),
                             )
                         }
                     _scheduleItems.value = mappedData

--- a/app/src/main/java/org/memento/presentation/util/FormatDate.kt
+++ b/app/src/main/java/org/memento/presentation/util/FormatDate.kt
@@ -140,13 +140,18 @@ fun formatEditTime(dateString: String): String {
     }
 }
 
-fun formatTimeTo12Hour(timeString: String): String {
-    val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ENGLISH)
-    val outputFormat = SimpleDateFormat("h a", Locale.ENGLISH)
+private val isoFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ENGLISH)
+private val hourOnlyFormatter = DateTimeFormatter.ofPattern("h a", Locale.ENGLISH)
+private val fullTimeFormatter = DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH)
 
+fun formatTimeTo12Hour(timeString: String): String {
     return try {
-        val date = inputFormat.parse(timeString)
-        outputFormat.format(date ?: Date())
+        val time = LocalDateTime.parse(timeString, isoFormatter)
+        if (time.minute == 0) {
+            time.format(hourOnlyFormatter)
+        } else {
+            time.format(fullTimeFormatter)
+        }
     } catch (e: Exception) {
         timeString
     }

--- a/app/src/main/java/org/memento/presentation/util/FormatDate.kt
+++ b/app/src/main/java/org/memento/presentation/util/FormatDate.kt
@@ -2,6 +2,7 @@ package org.memento.presentation.util
 
 import timber.log.Timber
 import java.text.SimpleDateFormat
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -154,6 +155,45 @@ fun formatTimeTo12Hour(timeString: String): String {
         }
     } catch (e: Exception) {
         timeString
+    }
+}
+
+fun formatTimeRangeWithDuration(
+    start: String,
+    end: String,
+): String {
+    return try {
+        val startTime = LocalDateTime.parse(start, isoFormatter)
+        val endTime = LocalDateTime.parse(end, isoFormatter)
+        val duration = Duration.between(startTime, endTime)
+
+        val formattedStart =
+            if (startTime.minute == 0) {
+                startTime.format(DateTimeFormatter.ofPattern("h a", Locale.ENGLISH))
+            } else {
+                startTime.format(DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH))
+            }
+
+        val formattedEnd =
+            if (endTime.minute == 0) {
+                endTime.format(DateTimeFormatter.ofPattern("h a", Locale.ENGLISH))
+            } else {
+                endTime.format(DateTimeFormatter.ofPattern("h:mm a", Locale.ENGLISH))
+            }
+
+        val durationString =
+            buildString {
+                val hours = duration.toHours()
+                val minutes = duration.toMinutes() % 60
+                if (hours > 0) append("${hours}h")
+                if (minutes > 0) {
+                    if (isNotEmpty()) append(" ")
+                    append("${minutes}m")
+                }
+            }
+        "$formattedStart - $formattedEnd${if (durationString.isNotEmpty()) " ($durationString)" else ""}"
+    } catch (e: Exception) {
+        "$start - $end"
     }
 }
 


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #148 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 401 에러 발생 -> 로그아웃 로직
  - 리프레시 토큰 마저 만료 된 상황 -> 해당 상황엔 로그아웃이 필요
  - 현재 토큰 만료 시간이 매우매우 짧은 상황 (몇 시간만 지나도 토큰 만료, 리프레시 토큰 만료 되는 상황) -> 서버 측에 시간 늘려달라고 해야 됨!
  - Interceptor에서 리프레시 토큰까지까지 만료를 감지하면 Global Event를 발생 시켜서 로그아웃 되도록 브로드 캐스트
- 투데이 스크린 시간 파싱
  - 상세 다이얼로그 분 단위 표시
  - 투데이 화면 내 분 단위 및 duration 표시

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

https://github.com/user-attachments/assets/199ee6b5-e1a1-485c-a990-8bdb1139cfeb

와우ㅋ 갑자기 토큰 만료돼서 로그아웃 로직도 찍혀따

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
오랜만이야 ~~~ 😍😍😍😍
FormatDate 파일에 반복되는 객체 생성이 많아서 언젠가 수정이 필요해 보이넴!!